### PR TITLE
removing `react-highcharts` reference from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,6 @@
 
 >react-froala-wyswiyg provides React bindings to the Froala WYSIWYG editor VERSION 2.
 
-## Installation
-
-```bash
-npm install react-highcharts --save
-```
-
 ## Usage
 
 #### 1. Install the React component.


### PR DESCRIPTION
I could be mistaken, but I don't think this package requires installing `react-highcharts`. Since the installation step was already included in the "Usage" section, I just removed it entirely.