### PR TITLE
Fix events not triggered

### DIFF
--- a/lib/FroalaEditorFunctionality.jsx
+++ b/lib/FroalaEditorFunctionality.jsx
@@ -16,10 +16,15 @@ export default class FroalaEditorFunctionality extends React.Component {
     // Editor element.
     this.editor = null;
 
-    // Editor options config
+    // Editor config
     this.config = {
       immediateReactModelUpdate: false,
       reactIgnoreAttrs: null
+    };
+
+    // Editor options
+    this.options = {
+      
     };
 
     this.editorInitialized = false;
@@ -69,6 +74,7 @@ export default class FroalaEditorFunctionality extends React.Component {
     }
 
     this.config = this.props.config || this.config;
+    this.options = this.props.options || this.options;
 
     this.$element = $(this.refs.el);
 
@@ -230,7 +236,7 @@ export default class FroalaEditorFunctionality extends React.Component {
   }
 
   registerEvents () {
-    let events = this.config.events;
+    let events = this.options.events;
     if (!events) {
       return;
     }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -64,7 +64,7 @@ module.exports = {
     modules: ['./node_modules']
   },
   output: {
-    filename: 'dist/[name]' + filenamePostfix + '.js',
+    filename: '[name]' + filenamePostfix + '.js',
     libraryTarget: 'umd',
     library: '[name]'
   }


### PR DESCRIPTION
Fixes:
- Initialised `events` from `options` instead of `config`.
- Webpack outputs module into `dist/dist` instead of `dist`.