### PR TITLE
Change refs from static to callback refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,9 @@ The object received by the function will contain the following methods:
 
 ## Using type definition file
 `index.d.ts` file is the type definition file for this repository. It is placed inside lib folder.In order to use it in your code , use the following line:
+```
 ///<reference path= "index.d.ts" />
+```
 where path is the location of index.d.ts file.
 
 ## Displaying HTML

--- a/demo/webpack.config.js
+++ b/demo/webpack.config.js
@@ -53,7 +53,7 @@ module.exports = {
 
   resolve: {
     alias: {
-      "react-froala-wysiwyg": '../../dist'
+      "react-froala-wysiwyg": '../../dist/dist'
     },
     modules: ['node_modules']
   },

--- a/lib/FroalaEditor.jsx
+++ b/lib/FroalaEditor.jsx
@@ -3,6 +3,6 @@ import FroalaEditorFunctionality from './FroalaEditorFunctionality.jsx';
 
 export default class FroalaEditor extends FroalaEditorFunctionality {
   render () {
-    return <this.tag ref="el">{this.props.children}</this.tag>;
+    return <this.tag ref={el => this.el = el}>{this.props.children}</this.tag>;
   }
 }

--- a/lib/FroalaEditorA.jsx
+++ b/lib/FroalaEditorA.jsx
@@ -5,7 +5,7 @@ export default class FroalaEditorA extends FroalaEditorFunctionality {
 
   render () {
     return (
-      <a ref='el'>{this.props.children}</a>
+      <a ref={el => this.el = el}>{this.props.children}</a>
     );
   }
 }

--- a/lib/FroalaEditorButton.jsx
+++ b/lib/FroalaEditorButton.jsx
@@ -5,7 +5,7 @@ export default class FroalaEditorButton extends FroalaEditorFunctionality {
 
   render () {
     return (
-      <button ref='el'>{this.props.children}</button>
+      <button ref={el => this.el = el}>{this.props.children}</button>
     );
   }
 }

--- a/lib/FroalaEditorFunctionality.jsx
+++ b/lib/FroalaEditorFunctionality.jsx
@@ -38,7 +38,7 @@ export default class FroalaEditorFunctionality extends React.Component {
 
   // After first time render.
   componentDidMount () {
-    let tagName = this.refs.el.tagName.toLowerCase();
+    let tagName = this.el.tagName.toLowerCase();
     if (this.SPECIAL_TAGS.indexOf(tagName) != -1) {
       this.tag = tagName;
       this.hasSpecialTag = true;
@@ -70,12 +70,12 @@ export default class FroalaEditorFunctionality extends React.Component {
 
     this.config = this.props.config || this.config;
 
-    this.$element = $(this.refs.el);
-    
+    this.$element = $(this.el);
+
     if(this.props.model) {
       this.$element[0].innerHTML = this.props.model;
     }
-    
+
     this.setContent(true);
 
     this.registerEvents();

--- a/lib/FroalaEditorImg.jsx
+++ b/lib/FroalaEditorImg.jsx
@@ -4,7 +4,7 @@ import FroalaEditorFunctionality from './FroalaEditorFunctionality.jsx';
 export default class FroalaEditorImg extends FroalaEditorFunctionality {
   render () {
     return (
-      <img ref='el'/>
+      <img ref={el => this.el = el}/>
     );
   }
 }

--- a/lib/FroalaEditorInput.jsx
+++ b/lib/FroalaEditorInput.jsx
@@ -5,7 +5,7 @@ export default class FroalaEditorInput extends FroalaEditorFunctionality {
 
   render () {
     return (
-      <input ref='el'/>
+      <input ref={el => this.el = el}/>
     );
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,21 +47,21 @@
     "nightwatch": "^0.9.6",
     "postcss-loader": "^2.1.4",
     "raw-loader": "^0.5.1",
-    "react": "^15.0.0",
+    "react": "^16.0.0",
     "react-addons-test-utils": "^15.0.0",
-    "react-dom": "^15.0.0",
+    "react-dom": "^16.0.0",
     "react-highlight": "^0.9.0",
     "sinon": "^1.17.4",
     "style-loader": "^0.21.0",
     "url-loader": "^0.5.5",
     "webpack": "^4.6.0",
-    "webpack-cli": "^2.0.15",
+    "webpack-cli": "^3.1.3",
     "webpack-dev-server": "^3.1.3"
   },
   "scripts": {
     "build": "webpack-cli && webpack-cli -p",
-    "demo": "cd demo && webpack-cli && ../node_modules/.bin/webpack-dev-server --port 4000 --content-base dist/",
-    "prepublish": "npm run build && bash lib/copy_bundles.sh"
+    "demo": "cd demo && webpack-cli && \"../node_modules/.bin/webpack-dev-server\" --port 4000 --content-base dist/",
+    "prepublishOnly": "npm run build && bash lib/copy_bundles.sh"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-froala-wysiwyg",
-  "version": "2.9.4-1",
+  "version": "2.9.5",
   "description": "React component for Froala WYSIWYG HTML rich text editor.",
   "main": "index.js",
   "author": "Froala Labs",
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "create-react-class": "^15.5.2",
-    "froala-editor": "2.9.4"
+    "froala-editor": "2.9.5"
   },
   "devDependencies": {
     "babel": "^6.23.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-froala-wysiwyg",
-  "version": "2.9.5",
+  "version": "2.9.5-1",
   "description": "React component for Froala WYSIWYG HTML rich text editor.",
   "main": "index.js",
   "author": "Froala Labs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-froala-wysiwyg",
-  "version": "2.9.3",
+  "version": "2.9.4",
   "description": "React component for Froala WYSIWYG HTML rich text editor.",
   "main": "index.js",
   "author": "Froala Labs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-froala-wysiwyg",
-  "version": "2.9.4",
+  "version": "2.9.4-1",
   "description": "React component for Froala WYSIWYG HTML rich text editor.",
   "main": "index.js",
   "author": "Froala Labs",
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "create-react-class": "^15.5.2",
-    "froala-editor": "2.9.3"
+    "froala-editor": "2.9.4"
   },
   "devDependencies": {
     "babel": "^6.23.0",


### PR DESCRIPTION
In the process of integrating Froala with [Strapi](https://strapi.io/) I was getting the [following error](https://reactjs.org/docs/error-decoder.html/?invariant=290&args[]=el) when running a production build:

```
Element ref was specified as a string (el) but no owner was set. 
This could happen for one of the following reasons: 
1. You may be adding a ref to a function component 
2. You may be adding a ref to a component that was not created inside a component's render method
3. You have multiple copies of React loaded See https://fb.me/react-refs-must-have-owner for more information.
```

I saw that Froala used string refs (`ref='el'`) which is a [legacy api](https://reactjs.org/docs/refs-and-the-dom.html#legacy-api-string-refs) of setting refs in React.

I've updated the way refs are handled and the production build was able to work. I've tested the demo and it also works as intended. Is there anything more I should test with?

Strapi deps:
```
 "strapi": "3.0.0-alpha.26.1",
 "react": "^16.8.4",
```