### PR TITLE
Simplify TypeScript definitions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -379,13 +379,6 @@ The object received by the function will contain the following methods:
 - **destroy**: Call this method to destroy the Froala Editor
 - **getEditor**: Call this method to retrieve the editor that was created. This method will return *null* if the editor was not yet created
 
-## Using type definition file
-`index.d.ts` file is the type definition file for this repository. It is placed inside lib folder.In order to use it in your code , use the following line:
-```
-///<reference path= "index.d.ts" />
-```
-where path is the location of index.d.ts file.
-
 ## Displaying HTML
 
 To display content created with the froala editor use the `FroalaEditorView` component.

--- a/lib/FroalaEditorA.d.ts
+++ b/lib/FroalaEditorA.d.ts
@@ -1,0 +1,1 @@
+export { default } from '.';

--- a/lib/FroalaEditorButton.d.ts
+++ b/lib/FroalaEditorButton.d.ts
@@ -1,0 +1,1 @@
+export { default } from '.';

--- a/lib/FroalaEditorImg.d.ts
+++ b/lib/FroalaEditorImg.d.ts
@@ -1,0 +1,1 @@
+export { default } from '.';

--- a/lib/FroalaEditorInput.d.ts
+++ b/lib/FroalaEditorInput.d.ts
@@ -1,0 +1,1 @@
+export { default } from '.';

--- a/lib/FroalaEditorView.d.ts
+++ b/lib/FroalaEditorView.d.ts
@@ -1,0 +1,1 @@
+export { default } from '.';

--- a/lib/copy_bundles.sh
+++ b/lib/copy_bundles.sh
@@ -2,3 +2,4 @@
 rm -rf ./bundle
 pwd
 cp -r ./dist/* ./
+cp -r ./lib/*.d.ts ./

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,93 +1,15 @@
-declare module 'react-froala-wysiwyg'
-{
+import * as React from 'react';
 
-
-export interface MyComponentProps {
-   tag?:string;
-   config?: object;
-   model?: string| object|null;
-   onModelChange?: object;
-   onManualControllerReady?: object;
+export interface FroalaEditorProps {
+  tag?: string;
+  config?: object;
+  model?: string | object | null;
+  onModelChange?: object;
+  onManualControllerReady?: object;
 }
 
-
-export default class  FroalaEditor extends React.Component<MyComponentProps>{
-   destroy():void;
-   getEditor(): any;
-   initialize() : object;
-}
-
-}
-
-declare module 'react-froala-wysiwyg/FroalaEditorView'
-{
-   export interface MyComponentProps {
-      tag?:string;
-      config?: object;
-      model?: string| object|null;
-      onModelChange?: object;
-      onManualControllerReady?: object;
-   }
-export  default class  FroalaEditorView extends React.Component<MyComponentProps>
-{
-
-}
-}
-
-declare module 'react-froala-wysiwyg/FroalaEditorImg'
-{
-   export interface MyComponentProps {
-      tag?:string;
-      config?: object;
-      model?: string| object|null;
-      onModelChange?: object;
-      onManualControllerReady?: object;
-   }
-export default class  FroalaEditorImg extends React.Component<MyComponentProps>
-{
-
-}
-}
-
-declare module 'react-froala-wysiwyg/FroalaEditorA'
-{
-   export interface MyComponentProps {
-      tag?:string;
-      config?: object;
-      model?: string| object|null;
-      onModelChange?: object;
-      onManualControllerReady?: object;
-   }
-export  default class  FroalaEditorA extends React.Component<MyComponentProps>
-{
-
-}
-}
-declare module 'react-froala-wysiwyg/FroalaEditorButton'
-{
-   export interface MyComponentProps {
-      tag?:string;
-      config?: object;
-      model?: string| object|null;
-      onModelChange?: object;
-      onManualControllerReady?: object;
-   }
-export default class  FroalaEditorButton extends React.Component<MyComponentProps>
-{
-
-}
-}
-declare module 'react-froala-wysiwyg/FroalaEditorInput'
-{
-   export interface MyComponentProps {
-      tag?:string;
-      config?: object;
-      model?: string| object|null;
-      onModelChange?: object;
-      onManualControllerReady?: object;
-   }
-export default class  FroalaEditorInput extends React.Component<MyComponentProps>
-{
-
-}
+export default class FroalaEditor extends React.Component<FroalaEditorProps> {
+  destroy(): void;
+  getEditor(): any;
+  initialize(): object;
 }


### PR DESCRIPTION
`.d.ts` declaration files are now published next to the compiled modules `index.js` (`index.d.ts`), `FroalaEditorA.js` (`FroalaEditorA.d.ts`), etc so that no configuration is necessary.