### PR TITLE
Fix initialization events

### DIFF
--- a/lib/FroalaEditorFunctionality.jsx
+++ b/lib/FroalaEditorFunctionality.jsx
@@ -87,12 +87,6 @@ export default class FroalaEditorFunctionality extends React.Component {
     this.config.events.initialized = () => this.initListeners();
 
     this.editor = new FroalaEditor(this.element, this.config);
-    // Call init events.
-    if (this._initEvents) {
-      for (let i = 0; i < this._initEvents.length; i++) {
-        this._initEvents[i].call(this.editor);
-      }
-    }
   }
 
   setContent(firstTime) {
@@ -231,6 +225,13 @@ export default class FroalaEditorFunctionality extends React.Component {
       this.editor.events.on('keyup', function () {
         self.updateModel();
       });
+    }
+
+    // Call init events.
+    if (this._initEvents) {
+      for (let i = 0; i < this._initEvents.length; i++) {
+        this._initEvents[i].call(this.editor);
+      }
     }
   }
 


### PR DESCRIPTION
When done the previous way, the editor is not yet initialized and the model doesn't get set properly.