### PR TITLE
Simplify import for TypeScript Users

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.0.5",
   "description": "React component for Froala WYSIWYG HTML rich text editor.",
   "main": "index.js",
+  "types": "./lib/index.d.ts",
   "author": "Froala Labs",
   "keywords": [
     "react",


### PR DESCRIPTION
Should not need to manually copy / import typescript definitions with 
```
/// <reference path="{path}/index.d.ts" />
```

This is considered old / deprecated / *red flag*
https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#red-flags

This will allow using 
```
import FroalaEditor from "react-froala-wysiwyg";
```
Without any further includes / imports.