### PR TITLE
Remove deprecated componentWillMount hook

### DIFF
--- a/lib/FroalaEditorFunctionality.jsx
+++ b/lib/FroalaEditorFunctionality.jsx
@@ -8,7 +8,7 @@ export default class FroalaEditorFunctionality extends React.Component {
 
     // Tag on which the editor is initialized.
     this.defaultTag = 'div';
-    this.tag = this.props.tag || this.defaultTag;
+    this.tag = props.tag || this.defaultTag;
     this.listeningEvents = [];
 
     // Jquery wrapped element.

--- a/lib/FroalaEditorFunctionality.jsx
+++ b/lib/FroalaEditorFunctionality.jsx
@@ -7,8 +7,8 @@ export default class FroalaEditorFunctionality extends React.Component {
     super(props);
 
     // Tag on which the editor is initialized.
-    this.tag = null;
     this.defaultTag = 'div';
+    this.tag = this.props.tag || this.defaultTag;
     this.listeningEvents = [];
 
     // Jquery wrapped element.
@@ -30,11 +30,6 @@ export default class FroalaEditorFunctionality extends React.Component {
     this.hasSpecialTag = false;
 
     this.oldModel = null;
-  }
-
-  // Before first time render.
-  componentWillMount() {
-    this.tag = this.props.tag || this.defaultTag;
   }
 
   // After first time render.


### PR DESCRIPTION
As per React docs (https://reactjs.org/docs/react-component.html#unsafe_componentwillmount), `componentWillMount` is no longer a safe lifecycle hook. In recent versions of React, this package is throwing a console warning regarding this hook.

In this instance, it can be removed in favour of setting the `tag` class property in the constructor instead.