### PR TITLE
Fix state sync issue before `editor.html` is available

### DIFF
--- a/lib/FroalaEditorFunctionality.jsx
+++ b/lib/FroalaEditorFunctionality.jsx
@@ -25,6 +25,9 @@ export default class FroalaEditorFunctionality extends React.Component {
 
     this.editorInitialized = false;
 
+    // Track status of this.editor for prop updates
+    this.isEditorAvailable = false;
+
     this.SPECIAL_TAGS = ['img', 'button', 'input', 'a'];
     this.INNER_HTML_ATTR = 'innerHTML';
     this.hasSpecialTag = false;
@@ -57,8 +60,18 @@ export default class FroalaEditorFunctionality extends React.Component {
   }
 
   componentDidUpdate() {
-    if (JSON.stringify(this.oldModel) == JSON.stringify(this.props.model)) {
+    // Only return when props match if the editor is available. Otherwise, we need still need to update to keep
+    // things in sync
+    if (
+      JSON.stringify(this.oldModel) == JSON.stringify(this.props.model) &&
+      this.isEditorAvailable === true
+    ) {
       return;
+    }
+
+    // Update editor availability status when it first becomes available
+    if (this.isEditorAvailable === false && this.editor.html) {
+      this.isEditorAvailable = true;
     }
 
     this.setContent();


### PR DESCRIPTION
It's possible to miss a model update if the value changes before `editor.html` is available since Froala's internal state on `this.oldModel` will be updated with the new value, but not actually displayed visually because `editor.html` is not available.

I've tried to simulate a basic case here:
https://codesandbox.io/s/froala-react-h7jg6

I'm sure there's a more elegant way to resolve this, but this PR creates a new internal state flag for `editor.html` availability and triggers `setContent` even if the props match if the editor was not previously available but is now.