### PR TITLE
Allow React 17 in the peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "javascript"
   ],
   "peerDependencies": {
-    "react": "~0.14 || ^15.0.0 || ^16.0.0",
-    "react-dom": "~0.14 || ^15.0.0 || ^16.0.0"
+    "react": "~0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0",
+    "react-dom": "~0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0"
   },
   "dependencies": {
     "create-react-class": "^15.5.2",


### PR DESCRIPTION
Npm 7 doesn't like installing without using --legacy-peer-deps