### PR TITLE
Support React 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "javascript"
   ],
   "peerDependencies": {
-    "react": "~0.14 || ^15.0.0 || ^16.0.0",
-    "react-dom": "~0.14 || ^15.0.0 || ^16.0.0"
+    "react": "~0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0",
+    "react-dom": "~0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0"
   },
   "dependencies": {
     "create-react-class": "^15.5.2",


### PR DESCRIPTION
React 17 has been out since October last year. It seems react-froala-wysiwyg does not need any updates to just work with it. Would it be possible to add it to the peerDependencies so we can upgrade without conflicts? :-)