### PR TITLE
Remove setting of innerHTML when initializing

### DIFF
--- a/lib/FroalaEditorFunctionality.jsx
+++ b/lib/FroalaEditorFunctionality.jsx
@@ -61,10 +61,10 @@ export default class FroalaEditorFunctionality extends React.Component {
 
   // Return cloned object
    clone(item) {
-  	const me = this;  
+  	const me = this;
       if (!item) { return item; } // null, undefined values check
 
-      let types = [ Number, String, Boolean ], 
+      let types = [ Number, String, Boolean ],
           result;
 
       // normalizing primitives if someone did new String('aaa'), or new Number('444');
@@ -77,13 +77,13 @@ export default class FroalaEditorFunctionality extends React.Component {
       if (typeof result == "undefined") {
           if (Object.prototype.toString.call( item ) === "[object Array]") {
               result = [];
-              item.forEach(function(child, index, array) { 
+              item.forEach(function(child, index, array) {
                   result[index] = me.clone( child );
               });
           } else if (typeof item == "object") {
               // testing that this is DOM
               if (item.nodeType && typeof item.cloneNode == "function") {
-                  result = item.cloneNode( true );    
+                  result = item.cloneNode( true );
               } else if (!item.prototype) { // check that this is a literal
                   if (item instanceof Date) {
                       result = new Date(item);
@@ -107,7 +107,7 @@ export default class FroalaEditorFunctionality extends React.Component {
       }
       return result;
   }
-  
+
   createEditor() {
     if (this.editorInitialized) {
       return;
@@ -117,10 +117,6 @@ export default class FroalaEditorFunctionality extends React.Component {
     this.config =  {...this.config};
 
     this.element = this.el;
-
-    if (this.props.model) {
-      this.element.innerHTML = this.props.model;
-    }
 
     this.setContent(true);
 


### PR DESCRIPTION
This patches a serious XSS vulnerability where any string value containing malicious code will be executed if passed as the initial value to the `model` prop in `FroalaEditorComponent`.

### Steps to reproduce the issue
1. Run the startup steps and `npm run demo`
2. Navigate to the `Full Featured Example` demo
3. Replace the initial `content` state with an obvious XSS payload like `<img src onerror="alert(document.cookie)"/>`
4. Refresh the demo. The alert will run.

I have a codesandbox demonstrating the same: https://codesandbox.io/s/new-violet-qd52th?file=/src/App.js (there is some unrelated error happening once Froala is initialized, I have no idea what's happening there)

### Reasoning
The vanilla Froala package also supports an "initial value" by initializing Froala on a node that already has HTML content. The difference with the React wrapper is that we pass the initial value as a _string_, and not HTML that's already rendered into the page. I believe it's fair for users of this library to assume that the initial model value is treated the same as any subsequent values (i.e. subject to the same sanitization, `htmlAllowedAttrs`, `htmlAllowedTags`, etc).

React itself is very strict about how/when innerHTML is set from a string (see https://reactjs.org/docs/dom-elements.html#dangerouslysetinnerhtml) and libraries should follow suit.

### What has changed
I've simply removed the step on initialization where we set innerHTML before initializing. To be honest I'm not sure the original intention of this step, since there is not much context in the commit history:

* It was added here: https://github.com/froala/react-froala-wysiwyg/commit/e7d6d675d6ec99951ba696523e5653def8dc7bd2 when adding a `this.el` ref to all components
* It was removed here https://github.com/froala/react-froala-wysiwyg/commit/423eee2f790ffb6930067fd87c3c1794341ed9cb, looks like a revert
* It was re-added here https://github.com/froala/react-froala-wysiwyg/commit/c78150152e14b3461f85dde8b1d9ea9234963e02

In my testing, there is no change without this step. `this.setContent(true)` still sets HTML once Froala is initialized.

Happy to look into an alternate approach if there is an important case I'm not considering here.