### PR TITLE
v4.0.14:4409

### DIFF
--- a/lib/FroalaEditorFunctionality.jsx
+++ b/lib/FroalaEditorFunctionality.jsx
@@ -1,6 +1,5 @@
 import FroalaEditor from 'froala-editor';
 import React from 'react';
-import DOMPurify from 'dompurify';
 
 let lastId = 0;
 export default class FroalaEditorFunctionality extends React.Component {
@@ -120,14 +119,7 @@ export default class FroalaEditorFunctionality extends React.Component {
     this.element = this.el;
 
     if (this.props.model) {
-      let ValidDom = DOMPurify.sanitize(this.props.model, {
-        ALLOW_UNKNOWN_PROTOCOLS: true,
-        ALLOWED_URI_REGEXP: /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|cid|xmpp|xxx):|[^a-z]|[a-z+.]+(?:[^a-z+.\-:]|$))/i
-      });
-      if (JSON.stringify(this.oldModel) == JSON.stringify(this.props.model)) {
-        return;
-      }
-      this.element.innerHTML = ValidDom;
+      this.element.dangerouslySetInnerHTML = this.props.model;
     }
 
     this.setContent(true);

--- a/lib/FroalaEditorFunctionality.jsx
+++ b/lib/FroalaEditorFunctionality.jsx
@@ -1,5 +1,6 @@
 import FroalaEditor from 'froala-editor';
 import React from 'react';
+import DOMPurify from 'dompurify';
 
 let lastId = 0;
 export default class FroalaEditorFunctionality extends React.Component {
@@ -119,7 +120,14 @@ export default class FroalaEditorFunctionality extends React.Component {
     this.element = this.el;
 
     if (this.props.model) {
-      this.element.innerHTML = this.props.model;
+      let ValidDom = DOMPurify.sanitize(this.props.model, {
+        ALLOW_UNKNOWN_PROTOCOLS: true,
+        ALLOWED_URI_REGEXP: /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|cid|xmpp|xxx):|[^a-z]|[a-z+.]+(?:[^a-z+.\-:]|$))/i
+      });
+      if (JSON.stringify(this.oldModel) == JSON.stringify(this.props.model)) {
+        return;
+      }
+      this.element.innerHTML = ValidDom;
     }
 
     this.setContent(true);

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "create-react-class": "^15.5.2",
+    "dompurify": "^2.2.7",
     "froala-editor": "4.0.13"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   },
   "dependencies": {
     "create-react-class": "^15.5.2",
-    "dompurify": "^2.2.7",
     "froala-editor": "4.0.13"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixed: https://github.com/froala-labs/froala-editor-js-2/issues/4409
**RCA**: In this ticket they are using `innerHTML` but react is not supported to this property.
**Fixed**: We have updated `innerHTML` to `dangerouslySetInnerHTML` according to the react documentation.