### PR TITLE
v4.0.14:4409

### DIFF
--- a/lib/FroalaEditorFunctionality.jsx
+++ b/lib/FroalaEditorFunctionality.jsx
@@ -118,10 +118,6 @@ export default class FroalaEditorFunctionality extends React.Component {
 
     this.element = this.el;
 
-    if (this.props.model) {
-      this.element.dangerouslySetInnerHTML = this.props.model;
-    }
-
     this.setContent(true);
 
     // Default initialized.


### PR DESCRIPTION
Fixed: https://github.com/froala-labs/froala-editor-js-2/issues/4409
**RCA**:  In This ticket we have no need reset the `innerHTML`. when we have set the code ` this.element = this.el;` and get the element with the reference of ([here](https://github.com/froala/react-froala-wysiwyg/blob/master/lib/FroalaEditor.jsx#L6)). In this ticket as suggested PR is right.
**Fixed**:  We can remove the code to set the `innerHTML`.