### PR TITLE
FROALA-502 (Support for React 19)

### DIFF
--- a/lib/FroalaEditorFunctionality.jsx
+++ b/lib/FroalaEditorFunctionality.jsx
@@ -3,7 +3,7 @@
 import React from 'react';
 
 let lastId = 0;
-let FroalaEditor = null;
+import FroalaEditor from 'froala-editor';
 export default class FroalaEditorFunctionality extends React.Component {
   constructor(props) {
     super(props);
@@ -37,21 +37,17 @@ export default class FroalaEditorFunctionality extends React.Component {
 
   // After first time render.
   componentDidMount() {
-    import(/*webpackIgnore: true*/ 'froala-editor').then((module) => {
-      FroalaEditor = module.default;
+    let tagName = this.el.tagName.toLowerCase();
+    if (this.SPECIAL_TAGS.indexOf(tagName) != -1) {
+      this.tag = tagName;
+      this.hasSpecialTag = true;
+    }
 
-      let tagName = this.el.tagName.toLowerCase();
-      if (this.SPECIAL_TAGS.indexOf(tagName) != -1) {
-        this.tag = tagName;
-        this.hasSpecialTag = true;
-      }
-
-      if (this.props.onManualControllerReady) {
-        this.generateManualController();
-      } else {
-        this.createEditor();
-      }
-    });
+    if (this.props.onManualControllerReady) {
+      this.generateManualController();
+    } else {
+      this.createEditor();
+    }
   }
 
   componentWillUnmount() {

--- a/package.json
+++ b/package.json
@@ -18,11 +18,12 @@
     "javascript"
   ],
   "peerDependencies": {
-    "react": "~0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
-    "react-dom": "~0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+    "react": "~0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+    "react-dom": "~0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "dependencies": {
-    "froala-editor": "4.5.2"
+    "froala-editor": "4.5.2",
+    "serialize-javascript": "^6.0.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.25.9",
@@ -31,9 +32,9 @@
     "@babel/plugin-proposal-function-sent": "^7.25.9",
     "@babel/plugin-proposal-throw-expressions": "^7.25.9",
     "@babel/preset-env": "^7.26.0",
-    "@babel/preset-react": "^7.25.9",
+    "@babel/preset-react": "^7.27.1",
     "autoprefixer": "^10.4.20",
-    "babel-loader": "^8.0.0",
+    "babel-loader": "^10.0.0",
     "copy-webpack-plugin": "^12.0.2",
     "core-js": "^3.39.0",
     "css-loader": "^7.1.2",
@@ -42,13 +43,13 @@
     "highlight.js": "^11.10.0",
     "imports-loader": "^5.0.0",
     "jsdom": "^25.0.1",
-    "mocha": "^10.8.2",
+    "mocha": "^11.7.1",
     "mock-require": "^1.3.0",
-    "nightwatch": "^3.9.0",
+    "nightwatch": "^3.12.2",
     "postcss-loader": "^8.1.1",
     "raw-loader": "^0.5.1",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
     "react-highlight": "^0.15.0",
     "sinon": "^1.17.4",
     "style-loader": "^0.21.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -63,7 +63,8 @@ var config = {
   },
   externals: externals,
   resolve: {
-    modules: ['./node_modules']
+    modules: ['./node_modules'],
+    extensions: [".jsx"],
   },
   output: {
     globalObject: 'this',


### PR DESCRIPTION
## Description
This PR addresses an issue with accessing the Froala editor instance via a React ref. The following updates were made:
Modified the import of `froala-editor` to load the editor at initialization, enabling access to the editor instance via React ref.

Upgraded React to the latest stable version.

## Related Issue
https://iderawebdev.atlassian.net/browse/FROALA-502

## Changes Made
- [x] Change 1: Updated the Froala editor import to load the editor during component initialization.
- [x] Change 2: Upgraded React to the latest stable version.
