### PR TITLE
fix: update placeholderText dynamically when config changes

### DIFF
--- a/lib/FroalaEditorFunctionality.jsx
+++ b/lib/FroalaEditorFunctionality.jsx
@@ -54,7 +54,14 @@ export default class FroalaEditorFunctionality extends React.Component {
     this.destroyEditor();
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps) {
+    if (
+      this.props.config.placeholderText !== prevProps.config.placeholderText
+    ) {
+      this.editor.opts.placeholderText = this.props.config.placeholderText;
+      this.editor.placeholder.refresh();
+    }
+
     if (JSON.stringify(this.oldModel) == JSON.stringify(this.props.model)) {
       return;
     }


### PR DESCRIPTION
## Problem
The `placeholderText` option does not update when the `config` prop changes after the editor is initialized. This forces users to destroy and recreate the entire editor instance just to update the placeholder text.
## Solution
This PR adds a check in [componentDidUpdate](cci:1://file:///Users/hanjunho/Desktop/react-froala-wysiwyg/lib/FroalaEditorFunctionality.jsx:56:2-69:3) to detect changes to `config.placeholderText` and applies the update using Froala's official API:
1. Updates `editor.opts.placeholderText` with the new value
2. Calls `editor.placeholder.refresh()` to update the UI
