### PR TITLE
Fix serialize-javascript vulnerability: upgrade to 7.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "froala-editor": "5.1.0",
-    "serialize-javascript": "^6.0.2"
+    "serialize-javascript": "^7.0.3"
   },
   "devDependencies": {
     "@babel/cli": "^7.25.9",
@@ -35,7 +35,7 @@
     "@babel/preset-react": "^7.27.1",
     "autoprefixer": "^10.4.20",
     "babel-loader": "^10.0.0",
-    "copy-webpack-plugin": "^12.0.2",
+    "copy-webpack-plugin": "^14.0.0",
     "core-js": "^3.39.0",
     "css-loader": "^7.1.2",
     "exports-loader": "^0.6.2",
@@ -43,9 +43,7 @@
     "highlight.js": "^11.10.0",
     "imports-loader": "^5.0.0",
     "jsdom": "^25.0.1",
-    "mocha": "^11.7.1",
     "mock-require": "^1.3.0",
-    "nightwatch": "^3.12.2",
     "postcss-loader": "^8.1.1",
     "raw-loader": "^0.5.1",
     "react": "^19.1.0",


### PR DESCRIPTION
Ticket Link:- https://iderawebdev.atlassian.net/browse/FROALA-738

Issue:- serialize-javascript vulnerability: upgrade to 7.0.3

Fix:- to fix vulnerabilities updated the version of `serialize-javascript` and `copy-webpack-plugin` to `7.0.3` and `14.0.0` and removed dependencies like `mocha` and `nightwatch` which were not in use